### PR TITLE
fix: Resolve database schema relation naming conflict for objectives table

### DIFF
--- a/src/core/adapters/drizzleSqlite/schema.ts
+++ b/src/core/adapters/drizzleSqlite/schema.ts
@@ -334,8 +334,11 @@ export const objectivesRelations = relations(objectives, ({ one, many }) => ({
   parent: one(objectives, {
     fields: [objectives.parentId],
     references: [objectives.id],
+    relationName: "ObjectiveParent",
   }),
-  children: many(objectives),
+  children: many(objectives, {
+    relationName: "ObjectiveParent",
+  }),
   keyResults: many(keyResults),
 }));
 


### PR DESCRIPTION
## Summary
- Fixed Drizzle ORM error: "There are multiple relations between objectives tables"
- Added explicit `relationName: "ObjectiveParent"` to both parent and children relations in objectives schema
- Resolved database schema conflict for self-referencing objective relationships

## Test plan
- [x] TypeScript compilation passes
- [x] Code linting passes
- [x] Schema changes validated

🤖 Generated with [Claude Code](https://claude.ai/code)